### PR TITLE
Fix for vis amounts with different numbers of digits

### DIFF
--- a/thaumcrafthelper.js
+++ b/thaumcrafthelper.js
@@ -124,7 +124,7 @@
             var aspect;
             for (aspect in breakdown) {
                 if (breakdown.hasOwnProperty(aspect) && (!centivis.hasOwnProperty(aspect) || centivis[aspect] < amount)) {
-                    centivis[aspect] = amount;
+                    centivis[aspect] = Math.floor(amount);
                 }
             }
             return centivis;


### PR DESCRIPTION
Without this change, centivis[aspect] is a string, and therefore "20" > "100" instead of 20 < 100.
